### PR TITLE
Was missing the "CustomRank" Column

### DIFF
--- a/For Install/SQL/DarkCore-CMS-AuthBase.sql
+++ b/For Install/SQL/DarkCore-CMS-AuthBase.sql
@@ -13,4 +13,5 @@ ALTER TABLE account
 	ADD `country` VARCHAR(255) NULL DEFAULT NULL,
 	ADD `age` VARCHAR(255) NULL DEFAULT NULL,
 	ADD `foundus` VARCHAR(255) NULL DEFAULT NULL,
-	ADD `avatar` VARCHAR(255) NOT NULL DEFAULT 'images/avatars/darksoke.png';
+	ADD `avatar` VARCHAR(255) NOT NULL DEFAULT 'images/avatars/darksoke.png'
+	ADD 'CustomRank' VARCHAR(50) NOT NULL DEFAULT 'Member';


### PR DESCRIPTION
Added "CustomRank" and default "member" var (seems to only want to work with 50 characters)